### PR TITLE
Make delete-entry changes show up immediately

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -60,8 +60,24 @@
 
 .list-entry .entry-text {
     display: inline-block;
-    margin-left: 10px;
+    margin-left: 1vw;
+    margin-top: -1.2%;
     font-size:x-large;
+    
+}
+
+.list-entry-button {
+    display: inline-block;
+    width: 100px;
+    margin-left: .5vw;
+    font-size:x-large;
+}
+
+.entry-buttons {
+    display: flex;
+    width: 10vw;
+    margin-left: 3vw;
+    
     
 }
 
@@ -83,6 +99,12 @@
 
 .list-selection {
     background-color: #f0f0f0;
+    padding: 20px;
+    transition: background-color 0.3s; 
+}
+
+.list-selection-active {
+    background-color: #c0c0c0;
     padding: 20px;
     transition: background-color 0.3s; 
 }

--- a/src/app/listSlice.js
+++ b/src/app/listSlice.js
@@ -1,4 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
+import { act } from "react-dom/test-utils";
 
 export const listSlice = createSlice({
   name: "list",
@@ -6,6 +7,7 @@ export const listSlice = createSlice({
     data: null,
     userLists: [],
     activeListId: 'no current list',
+    newEntryTargetListId: 1,
   },
   reducers: {
     setData: (state, action) => {
@@ -41,10 +43,14 @@ export const listSlice = createSlice({
     setActiveListId: (state, action) => { // payload expects an integer for the id
       state.activeListId = action.payload;
       console.log("active list id set to "+ action.payload)
+    },
+
+    setNewEntryTargetListId: (state, action) => { // payload expects an integer for the id
+      state.newEntryTargetListId = action.payload
     }
 
   },
 });
 
-export const { setData, setUserLists, setActiveListId } = listSlice.actions;
+export const { setData, setUserLists, setActiveListId, setNewEntryTargetListId } = listSlice.actions;
 export default listSlice.reducer;

--- a/src/components/CreateEntry.js
+++ b/src/components/CreateEntry.js
@@ -1,10 +1,15 @@
 import React, { useEffect, useState } from "react";
 import BoredTodo from "./BoredTodo";
+import { useDispatch, useSelector } from "react-redux";
+import { setNewEntryTargetListId } from "../app/listSlice";
 
 function CreateEntry({ updateListSlice }) {
+  const dispatch = useDispatch();
   const [text, setText] = useState("");
   const [priority, setPriority] = useState(0);
-  const [listNum, setListNum] = useState(1);
+  // const [listNum, setListNum] = useState(1);
+
+  const listNum = useSelector((state) => state.list.newEntryTargetListId);
 
   const endpoint = "http://localhost:3001/createEntry";
 
@@ -20,7 +25,8 @@ function CreateEntry({ updateListSlice }) {
   }
 
   function saveListNum(e) {
-    setListNum(e.target.value);
+    // setListNum(e.target.value);
+    dispatch(setNewEntryTargetListId(e.target.value));
   }
 
   async function handleCreateEntry() {
@@ -50,7 +56,8 @@ function CreateEntry({ updateListSlice }) {
   function handleCreateBoredEntry(activity) {
     setText(activity);
     setPriority(Number(priority == null ? 0 : priority));
-    setListNum(Number(listNum === null ? 1 : listNum));
+    // setListNum(Number(listNum === null ? 1 : listNum));
+    dispatch(setNewEntryTargetListId(listNum === null ? 1 : listNum))
   }
 
   useEffect(() => {

--- a/src/components/Entry.js
+++ b/src/components/Entry.js
@@ -1,4 +1,6 @@
 import { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { setData } from "../app/listSlice";
 
 function Entry({
   completed,
@@ -16,6 +18,7 @@ function Entry({
   const [edit, setEdit] = useState(false);
   const [prevEntry, setPrevEntry] = useState("");
 
+  const dispatch = useDispatch();
   const update_endpoint = "http://localhost:3001/updateEntry/";
 
   const delete_endpoint = "http://localhost:3001/deleteEntry/";
@@ -69,8 +72,10 @@ function Entry({
     fetch(delete_endpoint + currentEntryId, {
       method: "DELETE",
     })
-      .then((response) => console.log("Deleted entry: " + response.status))
+      .then((response) => console.log("Deleted entry: " + entryText))
       .catch((error) => console.error(error));
+    dispatch(setData(null)); // needed or else there is this really weird bug
+    updateListSlice();
   }
 
   useEffect(() => {
@@ -95,10 +100,26 @@ function Entry({
               entryCompleted ? "strikethrough entry-text" : "entry-text"
             }
           >
-            {edit ? <input value={entryText} onChange={modifyEntryText}></input>: <p>{entryText}</p>}
+            {edit ? (
+              <p>
+                <input
+                  className="entry-text"
+                  value={entryText}
+                  onChange={modifyEntryText}
+                />
+              </p>
+            ) : (
+              <p>{entryText}</p>
+            )}
           </div>
-          <button onClick={() => editEntry()}>{edit ? "complete edit" : "edit"}</button>
-          <button onClick={() => deleteEntry()}>delete</button>
+          <div className="entry-buttons">
+            <button className="list-entry-button" onClick={() => editEntry()}>
+              {edit ? "OK" : "Edit"}
+            </button>
+            <button className="list-entry-button" onClick={() => deleteEntry()}>
+              Delete
+            </button>
+          </div>
         </>
       )}
     </div>

--- a/src/components/ListLabel.js
+++ b/src/components/ListLabel.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { setActiveListId, setData } from "../app/listSlice";
+import { setActiveListId, setData, setNewEntryTargetListId } from "../app/listSlice";
 function ListLabel({ list_id }) {
   const currList = useSelector((state) => state.list.data); // returns current list object json
   const currActiveListId = useSelector((state) => state.list.activeListId);
@@ -35,6 +35,7 @@ function ListLabel({ list_id }) {
       .catch((error) => console.error(error));
     dispatch(setData(null)); // needed or else there is this really weird bug
     dispatch(setActiveListId(list_id));
+    dispatch(setNewEntryTargetListId(list_id));
     updateListSlice();
   }
 
@@ -46,7 +47,7 @@ function ListLabel({ list_id }) {
   }, []);
 
   return (
-    <div className="list-selection" onClick={switchActiveList}>
+    <div className=  {currActiveListId == list_id ? 'list-selection-active' : 'list-selection' } onClick={switchActiveList}>
       List {list_id}
     </div>
   );


### PR DESCRIPTION
Changes made:
- Delete entry changes now show up after deleting the entry without needing to refresh the page.
- "Add to which list?" now automatically updates based on the current active list.
- Added some CSS to make the edit and delete buttons, as well as the edit text field look better.
- Added `newEntryTargetListId` to `listSlilce.js` as a state to automatically change list target for entry creation to current active list.